### PR TITLE
Improve command arguments & completions. Also print only the chara.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,7 +106,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "charasay"
-version = "1.0.1"
+version = "2.0.0"
 dependencies = [
  "clap",
  "clap_complete",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "charasay"
-version = "1.0.1"
+version = "2.0.0"
 authors = ["Latif Sulistyo <latifsulistyo.me@gmail.com>"]
 edition = "2021"
 description = "The future of cowsay 🐮! Colorful characters saying something 🗨️."

--- a/src/bin/chara.rs
+++ b/src/bin/chara.rs
@@ -3,7 +3,7 @@ use std::{
     path::PathBuf,
 };
 
-use charasay::{format_character, Chara, BUILTIN_CHARA};
+use charasay::{format_character, print_character, Chara, BUILTIN_CHARA};
 use clap::{Args, Command, CommandFactory, Parser, Subcommand};
 use clap_complete::{generate, Generator, Shell};
 use rand::seq::SliceRandom;
@@ -158,8 +158,28 @@ fn main() {
             println!("{}", charas)
         }
 
-        Commands::Print { charas: _ } => {
-            todo!()
+        Commands::Print { charas } => {
+            if charas.all {
+                let charas = BUILTIN_CHARA;
+                for chara in charas {
+                    println!("\n\n{}", chara);
+                    println!("{}", print_character(&Chara::Builtin(chara.to_string()),));
+                }
+            } else {
+                let chara = if charas.random {
+                    let charas = BUILTIN_CHARA;
+                    let choosen_chara = charas.choose(&mut rand::thread_rng()).unwrap().to_owned();
+                    Chara::Builtin(choosen_chara.to_string())
+                } else if let Some(s) = charas.chara {
+                    Chara::Builtin(s)
+                } else if let Some(path) = charas.file {
+                    Chara::File(path)
+                } else {
+                    Chara::Builtin("cow".to_string())
+                };
+
+                println!("{}", print_character(&chara));
+            }
         }
 
         Commands::Convert { image: _ } => todo!(),


### PR DESCRIPTION
- [x] I already read and understand the [contribution guide](https://github.com/latipun7/.github/blob/main/contributing.md#pull-requests "Pull Request Guide")

---

<!-- If this PR resolves existing issue, add the issue number next to # below, otherwise delete the "Closes #" -->

Closes #15

<!-- Give descriptions below -->
- Now choosing builtin chara or loading external chara file separated from one command, previously `chara say -f` accept both builtin and external file path. This is done to improve generated command completions.
- Use `chara say -c <builtin>` to choose builtin chara.
- Use `chara say -f <path>` to load external chara file.
- Hardcode builtin chara list into fixed array.
- Ability to print only the chara. See `chara help print`.

<!-- Once again, thank you for your contribution 😊 -->
