### PR TITLE
fix: add missing character after `$t` variable

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -286,7 +286,7 @@ fn parse_character(chara: &Chara, voice_line: &str) -> String {
 
 /// Format arguments to form complete charasay
 pub fn format_character(messages: &str, chara: &Chara, max_width: usize, think: bool) -> String {
-    let voice_line = if think { "o" } else { "╲" };
+    let voice_line = if think { "o " } else { "╲ " };
     let bubble_type = if think {
         BubbleType::Think
     } else {


### PR DESCRIPTION
<!--

Thank you for contributing 🥳

Please read the contribution guide especially in the pull request section.

Replace `space` inside [ ] with x if you already read it. Thanks.

-->

- [x] I already read and understand the [contribution guide](https://github.com/latipun7/.github/blob/main/contributing.md#pull-requests "Pull Request Guide")

---

<!-- If this PR resolves existing issue, add the issue number next to # below, otherwise delete the "Closes #" -->

Closes #30 

<!-- Give descriptions below -->

<!-- Once again, thank you for your contribution 😊 -->
