### PR TITLE
fix: handle multi-letter variable names in chara parser

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,7 +117,8 @@ fn parse_character(chara: &Chara, voice_line: &str) -> String {
     let charas = stripped_chara.split('+').collect::<Vec<_>>();
     let mut parsed = String::new();
 
-    let re = Regex::new(r"(?<var>\$\w).*=.*(?<val>\x1B\[.*m\s*).;").unwrap();
+    // Capture multi-letter variable names like $a, $ab, $abc
+    let re = Regex::new(r"(?<var>\$\w+)\s*=.*(?<val>\x1B\[.*?m\s*).;").unwrap();
     for chara in charas {
         // extract variable definition to HashMap
         let replacers: Vec<HashMap<&str, &str>> = re
@@ -139,12 +140,16 @@ fn parse_character(chara: &Chara, voice_line: &str) -> String {
             .replace("$x", "\x1B[49m  ")
             .replace("$t", voice_line);
 
-        // replace variable from character's body with actual value
-        for replacer in replacers {
-            chara_body = chara_body.replace(
-                replacer.get("var").copied().unwrap(),
-                replacer.get("val").copied().unwrap(),
-            );
+        // replace variable from character's body with actual value,
+        // sorting longest-first to avoid partial matches (e.g. $a inside $ab)
+        let mut sorted: Vec<(&&str, &&str)> = replacers
+            .iter()
+            .map(|r| (r.get("var").unwrap(), r.get("val").unwrap()))
+            .collect();
+        sorted.sort_by_key(|b| std::cmp::Reverse(b.0.len())); // longest var name first
+
+        for (var_name, val) in sorted {
+            chara_body = chara_body.replace(var_name, val);
         }
 
         parsed.push_str(&format!("{}\n\n\n", &chara_body))


### PR DESCRIPTION
## Bug Description

When using complex `.cow` files converted from images (e.g. via [Charc0al's converter](https://charc0al.github.io/cowsay-files/converter)), multi-letter variable names like `$ab`, `$cd`, etc. appear in the cowfile. Charasay's parser mishandled these, producing garbled ANSI output.

Fixes #51

## Root Cause

Two problems in `parse_character()` (`src/lib.rs`):

1. The regex `(?<var>\$\w)` only captured **one** word character after `$`. So from `$ab` it captured `$a`.
2. `.replace("\", ...)` replaced **all** occurrences of `$a` in the body — including the `$a` inside `$ab` — turning `$ab` into `<color_for_a>b`.

## Fix

**Two changes, same function:**

1. **Capture full variable names** — `\$\w` → `\$\w+` in the regex, so `$ab`, `$cd`, etc. are captured as whole variable names.

2. **Sort replacements longest-first** — replacers are sorted by variable name length descending (`$ab` before `$a`). By the time `$a`'s replacement runs, `$ab` is already replaced with its ANSI value, so there's no `$a` inside `$ab` to corrupt.

Note: Rust's `regex` crate uses a finite-automata engine without look-around support, so the sort-by-length approach was chosen over a negative lookahead.

## How to Verify

1. Create a chara file with both single-letter (`$a`, `$b`) and multi-letter (`$ab`, `$cd`) variables
2. Run `chara say -f test.chara "hello"`
3. Confirm no extraneous text artifacts appear — each variable is replaced with its own ANSI value

## Test Plan

- [x] Manual test with mixed single/multi-letter variables (`$a`, `$b`, `$ab`, `$cd`)
- [x] All 9 built-in charas verified (cow, pikachu, tux, ferris, kirby, mew, mario, nemo, cirno) — no regressions
- [x] Build compiles cleanly

## Risk Assessment

Low — the change is purely mechanical (wider regex + sorting). All existing single-letter-only chara files continue to work identically because `\$\w+` is a superset of `\$\w` and single-element sorting is a no-op.