### PR TITLE
fix: correct release file glob and bump artifact actions (download v8, upload v7)

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -120,7 +120,7 @@ jobs:
           fi
 
       - name: ⬆️ Upload Binary Artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ matrix.artifact-name }}
           path: ${{ matrix.artifact-name }}.zip
@@ -134,7 +134,7 @@ jobs:
 
     steps:
       - name: ⬇️ Download All Binary Artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           merge-multiple: true
 
@@ -155,4 +155,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           generate_release_notes: true
-          files: chara-*/*.zip
+          files: chara-*.zip


### PR DESCRIPTION
## Summary

Three changes:

1. **Fix release file glob** — With `merge-multiple: true` on `download-artifact`, zip files are flattened to root. Changed from `chara-*/*.zip` (expects subdirectories) to `chara-*.zip`.

2. **Bump `actions/download-artifact`** v4.3.0 → **v8.0.1** (latest). Breaking changes (safe for our usage): digest hash mismatch now defaults to `error`, non-zipped files not auto-extracted. Our artifacts are freshly built zipped files — no impact.

3. **Bump `actions/upload-artifact`** v4.6.2 → **v7.0.1** (latest). No API changes for our usage.

## Test Plan

- [x] CI passes
- [ ] Next tag push includes artifacts in the release